### PR TITLE
Fix 551

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -431,6 +431,7 @@ public class ImportHandler {
      *
      * @param files the list of file paths to process
      * @return a list of BibEntry objects to be imported, ensuring uniqueness
+     *
      */
     public List<BibEntry> getEntriesToImport(List<Path> files) {
         List<BibEntry> entriesToImport = new ArrayList<>();

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -436,7 +436,6 @@ public class ImportHandler {
     public List<BibEntry> getEntriesToImport(List<Path> files) {
         List<BibEntry> entriesToImport = new ArrayList<>();
         for (Path file : files) {
-
             if (FileUtil.isPDFFile(file)) {
                 var pdfImporterResult = contentImporter.importPDFContent(file);
                 List<BibEntry> pdfEntriesInFile = pdfImporterResult.getDatabase().getEntries();

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -423,6 +423,15 @@ public class ImportHandler {
         }
     }
 
+    /**
+     * This method processes a list of file paths to extract BibEntry objects for import.
+     * It ensures that only unique entries are added to the import list by checking for duplicates
+     * against the existing database entries. If a file is unsupported or contains no valid entries,
+     * an empty entry with a link is created to maintain the integrity of the import process.
+     *
+     * @param files the list of file paths to process
+     * @return a list of BibEntry objects to be imported, ensuring uniqueness
+     */
     public List<BibEntry> getEntriesToImport(List<Path> files) {
         List<BibEntry> entriesToImport = new ArrayList<>();
 
@@ -454,7 +463,6 @@ public class ImportHandler {
                 entriesToImport.add(createEmptyEntryWithLink(file));
             }
         }
-
         return entriesToImport;
     }
 }

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -435,7 +435,6 @@ public class ImportHandler {
      */
     public List<BibEntry> getEntriesToImport(List<Path> files) {
         List<BibEntry> entriesToImport = new ArrayList<>();
-
         for (Path file : files) {
 
             if (FileUtil.isPDFFile(file)) {

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -212,7 +212,6 @@ public class UnlinkedFilesDialogViewModel {
 
     /**
      * Extracts the file path from the given BibEntry.
-     *
      * @param entry The BibEntry instance from which to extract the file path
      * @return The file path if a valid file field exists in the BibEntry; otherwise, returns an empty path.
      */

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -210,8 +210,14 @@ public class UnlinkedFilesDialogViewModel {
         importFilesBackgroundTask.executeWith(taskExecutor);
     }
 
+    /**
+     * Extracts the file path from the given BibEntry.
+     *
+     * @param entry The BibEntry instance from which to extract the file path
+     * @return The file path if a valid file field exists in the BibEntry; otherwise, returns an empty path.
+     *
+     */
     private Path getFilePathFromEntry(BibEntry entry) {
-
         Optional<String> fileField = entry.getField(StandardField.FILE);
         if (fileField.isPresent()) {
             String fileFieldValue = fileField.get();

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -211,6 +211,12 @@ public class UnlinkedFilesDialogViewModel {
         importFilesBackgroundTask.executeWith(taskExecutor);
     }
 
+    /**
+     * Extracts the file path from the given BibEntry.
+     *
+     * @param entry The BibEntry instance from which to extract the file path
+     * @return The file path if a valid file field exists in the BibEntry; otherwise, returns an empty path.
+     */
     private Path getFilePathFromEntry(BibEntry entry) {
 
         Optional<String> fileField = entry.getField(StandardField.FILE);

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -33,7 +33,6 @@ import javafx.scene.control.TreeItem;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
-import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.gui.util.FileDialogConfiguration;

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -215,7 +215,6 @@ public class UnlinkedFilesDialogViewModel {
      *
      * @param entry The BibEntry instance from which to extract the file path
      * @return The file path if a valid file field exists in the BibEntry; otherwise, returns an empty path.
-     *
      */
     private Path getFilePathFromEntry(BibEntry entry) {
 

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -210,11 +210,6 @@ public class UnlinkedFilesDialogViewModel {
         importFilesBackgroundTask.executeWith(taskExecutor);
     }
 
-    /**
-     * Extracts the file path from the given BibEntry.
-     * @param entry The BibEntry instance from which to extract the file path
-     * @return The file path if a valid file field exists in the BibEntry; otherwise, returns an empty path.
-     */
     private Path getFilePathFromEntry(BibEntry entry) {
 
         Optional<String> fileField = entry.getField(StandardField.FILE);

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -7,8 +7,10 @@ import java.nio.file.DirectoryStream.Filter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -30,6 +32,7 @@ import javafx.scene.control.TreeItem;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.gui.util.FileDialogConfiguration;
@@ -42,6 +45,8 @@ import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.util.FileUpdateMonitor;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
@@ -81,6 +86,8 @@ public class UnlinkedFilesDialogViewModel {
     private final TaskExecutor taskExecutor;
 
     private final FunctionBasedValidator<String> scanDirectoryValidator;
+
+    private List<BibEntry> entriesToImportWithoutDuplicates;
 
     public UnlinkedFilesDialogViewModel(DialogService dialogService,
                                         UndoManager undoManager,
@@ -154,6 +161,24 @@ public class UnlinkedFilesDialogViewModel {
         }
         resultList.clear();
 
+        List<BibEntry> entriesToImport = importHandler.getEntriesToImport(fileList);
+
+        entriesToImportWithoutDuplicates = new ArrayList<>();
+
+        for (BibEntry entry : entriesToImport) {
+            Optional<BibEntry> existingDuplicate = importHandler.findDuplicate(bibDatabase, entry);
+            if (existingDuplicate.isPresent()) {
+                LOGGER.info("Skipping duplicate entry: {}", entry);
+            } else {
+                entriesToImportWithoutDuplicates.add(entry);
+            }
+        }
+
+        if (entriesToImportWithoutDuplicates.isEmpty()) {
+            LOGGER.warn("No unique entries to import, skipping background task.");
+            return;
+        }
+
         importFilesBackgroundTask = importHandler.importFilesInBackground(fileList, bibDatabase, preferences.getFilePreferences())
                                                  .onRunning(() -> {
                                                      progressValueProperty.bind(importFilesBackgroundTask.workDonePercentageProperty());
@@ -165,8 +190,42 @@ public class UnlinkedFilesDialogViewModel {
                                                      progressTextProperty.unbind();
                                                      taskActiveProperty.setValue(false);
                                                  })
-                                                 .onSuccess(resultList::addAll);
+                                                 .onSuccess(new Consumer<List<ImportFilesResultItemViewModel>>() {
+                                                     @Override
+                                                     public void accept(List<ImportFilesResultItemViewModel> importFilesResultItemViewModels) {
+                                                         if (entriesToImportWithoutDuplicates != null && !entriesToImportWithoutDuplicates.isEmpty()) {
+                                                             List<ImportFilesResultItemViewModel> convertedEntries = entriesToImportWithoutDuplicates.stream()
+                                                                                                                                                     .map(entry -> new ImportFilesResultItemViewModel(
+                                                                                                                                                             UnlinkedFilesDialogViewModel.this.getFilePathFromEntry(entry),
+                                                                                                                                                             true,
+                                                                                                                                                             "Imported successfully"))
+                                                                                                                                                     .collect(Collectors.toList());
+                                                             resultList.addAll(convertedEntries);
+                                                         } else {
+                                                             LOGGER.warn("No entries to import or list is not initialized properly.");
+                                                         }
+                                                     }
+                                                 });
+
         importFilesBackgroundTask.executeWith(taskExecutor);
+    }
+
+    private Path getFilePathFromEntry(BibEntry entry) {
+
+        Optional<String> fileField = entry.getField(StandardField.FILE);
+        if (fileField.isPresent()) {
+            String fileFieldValue = fileField.get();
+            String[] fileParts = fileFieldValue.split(":");
+
+            if (fileParts.length > 1) {
+                return Path.of(fileParts[1]);
+            } else {
+                LOGGER.warn("File field is not in the expected format: {}", fileFieldValue);
+            }
+        } else {
+            LOGGER.warn("No file associated with the entry: {}", entry);
+        }
+        return null;
     }
 
     /**
@@ -201,7 +260,7 @@ public class UnlinkedFilesDialogViewModel {
         } catch (IOException e) {
             LOGGER.error("Error exporting", e);
         }
-     }
+    }
 
     public ObservableList<FileExtensionViewModel> getFileFilters() {
         return this.fileFilterList;

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -196,10 +197,10 @@ public class UnlinkedFilesDialogViewModel {
                                                          if (entriesToImportWithoutDuplicates != null && !entriesToImportWithoutDuplicates.isEmpty()) {
                                                              List<ImportFilesResultItemViewModel> convertedEntries = entriesToImportWithoutDuplicates.stream()
                                                                                                                                                      .map(entry -> new ImportFilesResultItemViewModel(
-                                                                                                                                                             UnlinkedFilesDialogViewModel.this.getFilePathFromEntry(entry),
+                                                                                                                                                             Objects.requireNonNull(UnlinkedFilesDialogViewModel.this.getFilePathFromEntry(entry)),
                                                                                                                                                              true,
                                                                                                                                                              "Imported successfully"))
-                                                                                                                                                     .collect(Collectors.toList());
+                                                                                                                                                     .toList();
                                                              resultList.addAll(convertedEntries);
                                                          } else {
                                                              LOGGER.warn("No entries to import or list is not initialized properly.");
@@ -225,7 +226,7 @@ public class UnlinkedFilesDialogViewModel {
         } else {
             LOGGER.warn("No file associated with the entry: {}", entry);
         }
-        return null;
+        return Path.of("");
     }
 
     /**

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -216,6 +216,7 @@ public class UnlinkedFilesDialogViewModel {
      *
      * @param entry The BibEntry instance from which to extract the file path
      * @return The file path if a valid file field exists in the BibEntry; otherwise, returns an empty path.
+     *
      */
     private Path getFilePathFromEntry(BibEntry entry) {
 

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -1051,6 +1051,10 @@ public class BibEntry implements Cloneable {
         return keywords;
     }
 
+    public Optional<String> getCiteKey() {
+        return getField(InternalField.KEY_FIELD);
+    }
+
     public Optional<FieldChange> clearCiteKey() {
         return clearField(InternalField.KEY_FIELD);
     }


### PR DESCRIPTION
### Changes to the UnlinkedFilesDialogViewModel Class

**Updates to the startImport Method:**

- **Import Logic**: Calls the getEntriesToImport method of ImportHandler to retrieve the list of entries to be imported.
- **Deduplication Logic**: During the import process, checks for duplicate entries using the importHandler.findDuplicate method to ensure only unique entries are imported.
- **Logging**: Records appropriate warning logs when no unique entries are found.

**Import Result Handling:**

- Displays the results of successfully imported entries on the interface using resultList, ensuring that users can see the status and results of the import.

**Changes to the getFilePathFromEntry Method:**

- **Functionality**: Extracts the file path from the BibEntry, ensuring that the path format is correct. If the file field format does not meet expectations, logs appropriate warning messages.
- **Return Value**: Returns a valid file path; if there are no valid file fields, returns an empty path.

### Changes to the ImportHandler Class

**New Method getEntriesToImport:**

- This method is responsible for processing the incoming list of files and extracting importable BibEntry objects.
- Processes different types of files (e.g., PDF and BibTeX) and returns a list of unique entries.
- Creates empty entries for unsupported file types to maintain the integrity of the import process.

**Enhanced File Type Support:**

- Uses FileUtil within the method to check file types and handle them accordingly.

**Enhanced Logging:**

- Logs warnings and error messages during the import process of PDF and BibTeX files.

**Exception Handling:**

- Added exception handling for importing BibTeX files, capturing potential IOException.

### Changes to the BibEntry Class

**New Method getCiteKey():**

- **Functionality**: Provides a convenient method to retrieve the citation key (CiteKey) of the entry.
- **Purpose**: Simplifies access to citation key information when processing and checking entries, laying the foundation for subsequent duplicate entry detection.
